### PR TITLE
Setup.hs: Initialize

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,3 @@
+module Main where
+import Distribution.Simple
+main = defaultMain


### PR DESCRIPTION
ghc-bignum-orphans is required indirectly by Cabal since hashable (which is required directly by Cabal) depends on it. Cabal can be bootstrapped via Setup.hs files which are extracted from hackage tarballs and executed by [a Python script](https://github.com/haskell/cabal/tree/master/bootstrap).

In order for this to work properly, all direct and indirect dependencies of Cabal need to provide a Setup.hs file. ghc-bignum-orphans does presently not provide such a file which causes issues during bootstraping.